### PR TITLE
Update DotNetReportApiController.cs

### DIFF
--- a/Controllers/DotNetReportApiController.cs
+++ b/Controllers/DotNetReportApiController.cs
@@ -851,7 +851,7 @@ namespace ReportBuilder.Web.Controllers
 
                 var _dbtype = dbConfig["DatabaseType"]?.ToString() ?? dbtype;
                 string connectionString = dbConfig["ConnectionString"]?.ToString();
-                IDatabaseConnection databaseConnection = DatabaseConnectionFactory.GetConnection(dbtype);
+                IDatabaseConnection databaseConnection = DatabaseConnectionFactory.GetConnection(_dbtype);
 
                 var tables = new List<TableViewModel>();
                 var procedures = new List<TableViewModel>();


### PR DESCRIPTION
Fix: Use correct database type variable in LoadSetupSchema

Problem: The `LoadSetupSchema` method in `DotNetReportApiController.cs` was always creating SQL Server database connections regardless of the configured database type (PostgreSQL, MySQL, etc.).

Root Cause: Line 854 was using the static class variable `dbtype` instead of the local variable `_dbtype`: