### PR TITLE
Fix schedule modals omitting adminMode, breaking scheduling in Admin Mode

### DIFF
--- a/Scripts/dotnetreport.js
+++ b/Scripts/dotnetreport.js
@@ -4305,6 +4305,7 @@ var reportViewModel = function (options) {
 							data: {
 								method: "/ReportApi/DeleteReportSchedule",
 								model: JSON.stringify({
+									adminMode: self.adminMode(),
 									reportId: self.scheduleReportModal.reportId()								
 								})
 							}
@@ -4352,6 +4353,7 @@ var reportViewModel = function (options) {
 				data: {
 					method: "/ReportApi/SaveReportSchedule",
 					model: JSON.stringify({
+						adminMode: self.adminMode(),
 						reportId: self.scheduleReportModal.reportId(),
 						scheduleData: JSON.stringify(scheduleData)
 					})
@@ -4375,6 +4377,7 @@ var reportViewModel = function (options) {
 			data: {
 				method: "/ReportApi/GetReportSchedule",
 				model: JSON.stringify({
+					adminMode: self.adminMode(),
 					reportId: report.reportId
 				})
 			},
@@ -11911,6 +11914,7 @@ var dashboardViewModel = function (options) {
 							data: {
 								method: "/ReportApi/DeleteDashboardSchedule",
 								model: JSON.stringify({
+									adminMode: self.adminMode(),
 									dashboardId: self.scheduleDashboardModal.dashboardId()
 								})
 							}
@@ -11958,6 +11962,7 @@ var dashboardViewModel = function (options) {
 				data: {
 					method: "/ReportApi/SaveDashboardSchedule",
 					model: JSON.stringify({
+						adminMode: self.adminMode(),
 						dashboardId: self.scheduleDashboardModal.dashboardId(),
 						scheduleData: JSON.stringify(scheduleData)
 					})
@@ -11983,6 +11988,7 @@ var dashboardViewModel = function (options) {
 			data: {
 				method: "/ReportApi/GetDashboardSchedule",
 				model: JSON.stringify({
+					adminMode: self.adminMode(),
 					dashboardId: dashId
 				})
 			},


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                        An admin with Admin Mode ON can open, run, edit, and delete any report — but opening or saving a **schedule** for any report they don't own fails with a 500: `System.Exception: Could not validate access at DotNetReportApiController.ValidateAccess(...)`                                                                                                                                                                            
The schedule modal's `.fail()` handler swallows the error, so the modal silently shows an empty schedule form even when a schedule exists, and saving fails the same way.                                                                                                                                                
                                                                                                                                                                                                                                    
 ## Cause                                                                                                                                                                                                                          
The six schedule-modal `ajaxcall`s in `Scripts/dotnetreport.js` are the only builder calls that don't include `adminMode: self.adminMode()` in their `model` JSON:     
- `/ReportApi/GetReportSchedule`, `/ReportApi/SaveReportSchedule`, `/ReportApi/DeleteReportSchedule`                                                                                                                              
- `/ReportApi/GetDashboardSchedule`, `/ReportApi/SaveDashboardSchedule`, `/ReportApi/DeleteDashboardSchedule`                                                                                                                     
                                                                                                                                                                                                                                    Server-side, `ExecuteCallReportApi` therefore treats them as non-admin calls and runs `ValidateAccess` → `CheckReportAccess`, which denies reports the admin doesn't own.                                                                                                                                               
                                                                                                                                                                                                                                    
## Fix                                                                                                                                                                                                                            
Add `adminMode: self.adminMode()` to all six models, matching the rest of the file  (~40 other calls already pass it). No security change: the server only honors the flag after checking `settings.CanUseAdminMode`, so non-admin users are unaffected.                                                                                                                                                     

Reproduced and verified against the `dotnetreport` 6.3.0 NuGet package (ASP.NET Core).